### PR TITLE
adjust docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,16 @@
-version: "3.9"
 services:
   selenium:
     container_name: netflix_watcher_selenium
     image: seleniarm/standalone-chromium:latest
-    restart: always
+    restart: on-failure:5
     depends_on:
       - app
-    volumes:
-      - ./:/app
-    env_file:
-      - ./.env
-    ports:
-      - "4444:4444"
 
   app:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: netflix_watcher_app
-    restart: always
-    volumes:
-      - ./app:/app
+    restart: on-failure:5
     env_file:
       - ./.env


### PR DESCRIPTION
- remove version key which is deprecated
- remove volumes, env_file and ports from selenium
- set restart policy to on-failure with 5 retries

Expose port 4444 on selenium is a potential security problem, because this exposes the port to everybody